### PR TITLE
grub-mkconfig: move from / to pages/linux

### DIFF
--- a/pages/linux/grub-mkconfig.md
+++ b/pages/linux/grub-mkconfig.md
@@ -1,7 +1,7 @@
 # grub-mkconfig
 
 > Generate a GRUB configuration file.
-> More information: <https://www.gnu.org/software/grub/manual/grub/html_node/Invoking-grub_002dmkconfig.html>
+> More information: <https://www.gnu.org/software/grub/manual/grub/html_node/Invoking-grub_002dmkconfig.html>.
 
 - Do a dry run and print the configuration to stdout:
 


### PR DESCRIPTION
Mirror of https://github.com/tldr-pages/tldr/pull/5350

I discovered this oversight because I was looking at the files in this repo and I noticed an odd file, so I checked in the main repo and fixed it.